### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ test.after.each(() => {
 })
 
 test('calls increase', () => {
-  let spy = spyOn(counter, increase)
+  let spy = spyOn(counter, 'increase')
   counter.increase(5)
   assert.is(spy.called, true)
   assert.equal(spy.callCount, 1)

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ type Methods<Obj extends object> = {
  * import { spyOn } from 'nanospy'
  *
  * it('calls increase', () => {
- *   let increase = spyOn(counter, increase)
+ *   let increase = spyOn(counter, 'increase')
  *   counter.increase(5)
  *   expect(increase.called).toBe(true)
  *   expect(increase.callCount).toBe(1)


### PR DESCRIPTION
Based on type description, `spyOn` second parameter should be string.
https://github.com/ai/nanospy/blob/11364a4201f7b996962cda4acbd3ac782c5970dc/index.d.ts#L36

Just to clear up usage examples.