### PR TITLE
Preserve original function's length property in mocks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ export interface Spy<
   called: boolean
   callCount: number
   calls: Parameters<Fn>[]
+  length: number
   results: ReturnType<Fn>[]
   nextError(error: Error): void
   nextResult(result: ReturnType<Fn>): void

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ export function spy(cb) {
     }
   }
 
+  Object.defineProperty(fn, 'length', { value: cb ? cb.length : 0 });
   fn.called = false
   fn.callCount = 0
   fn.results = []

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -16,6 +16,7 @@ test('can spy on method', () => {
   is(method.called, false)
   equal(method.callCount, 0)
   equal(method.calls, [])
+  equal(method.length, 1)
   equal(method.results, [])
 
   equal(obj.method('a'), 'a!')
@@ -108,6 +109,7 @@ test('has spy for callback', () => {
   is(fn.called, false)
   equal(fn.callCount, 0)
   equal(fn.calls, [])
+  equal(fn.length, 0)
   equal(fn.results, [])
 
   is(fn('a', 'A'), undefined)
@@ -140,6 +142,8 @@ test('supports spy with callback', () => {
   let fn = spy((name: string): string => {
     return name + '!'
   })
+
+  equal(fn.length, 1)
 
   equal(fn('a'), 'a!')
   is(fn.called, true)


### PR DESCRIPTION
Some functions like [ramda's curry](https://ramdajs.com/docs/#curry) relies that [Function.length](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/length) is correct.

**Expected behaviour**
```js
const myFunction = (a, b) => a + b;
myFunction.length // 2

const fn = spy(myFunction);
fn.length // 2
```

**Current behaviour**
```js
const fn = spy(myFunction);
fn.length // 0
```